### PR TITLE
Implement missing schema tables and course management page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/success_academy
+STRIPE_SECRET_KEY=sk_test_yourkey
+NEXTAUTH_URL=http://localhost:3000

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Course {
+  id: number;
+  title: string;
+  price: number;
+  published_at?: string | null;
+}
+
+export default function MyCourses() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  useEffect(() => {
+    fetch("/api/instructor/courses")
+      .then((r) => r.json())
+      .then((d) => setCourses(d.courses));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">My Courses</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Title</th>
+            <th className="p-2">Price</th>
+            <th className="p-2">Published</th>
+          </tr>
+        </thead>
+        <tbody>
+          {courses.map((c) => (
+            <tr key={c.id} className="border-t">
+              <td className="p-2">{c.title}</td>
+              <td className="p-2">${c.price}</td>
+              <td className="p-2">{c.published_at ? "Yes" : "No"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -22,22 +22,61 @@ CREATE TABLE courses (
   published_at  TIMESTAMPTZ                   -- NEW
 );
 
--- Track every purchase so we can compute instructor earnings
-CREATE TABLE purchases (                       -- NEW
+-- Students -----------------------------------------------------------------
+CREATE TABLE students (
   id         SERIAL PRIMARY KEY,
-  student_id INTEGER      NOT NULL REFERENCES students(id), -- assumes students table exists
+  name       TEXT NOT NULL,
+  email      TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Track every purchase so we can compute instructor earnings
+CREATE TABLE purchases (
+  id         SERIAL PRIMARY KEY,
+  student_id INTEGER      NOT NULL REFERENCES students(id),
   course_id  INTEGER      NOT NULL REFERENCES courses(id),
   amount     NUMERIC(10,2) NOT NULL,
   created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 
--- add other tables below if you already had them …
+-- Course curriculum --------------------------------------------------------
+CREATE TABLE modules (
+  id         SERIAL PRIMARY KEY,
+  course_id  INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+  title      TEXT    NOT NULL,
+  position   INTEGER NOT NULL
+);
 
--- Purchases ---------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS purchases(
-  id SERIAL PRIMARY KEY,
-  student_id INT,
-  course_id  INT REFERENCES courses(id),
-  amount     NUMERIC(10,2),
+CREATE TABLE lessons (
+  id         SERIAL PRIMARY KEY,
+  module_id  INTEGER NOT NULL REFERENCES modules(id) ON DELETE CASCADE,
+  title      TEXT    NOT NULL,
+  position   INTEGER NOT NULL
+);
+
+CREATE TABLE media_files (
+  id         SERIAL PRIMARY KEY,
+  lesson_id  INTEGER NOT NULL REFERENCES lessons(id) ON DELETE CASCADE,
+  filename   TEXT    NOT NULL,
+  mime_type  TEXT    NOT NULL,
+  url        TEXT    NOT NULL
+);
+
+-- Affiliate program -------------------------------------------------------
+CREATE TABLE affiliates (
+  id         SERIAL PRIMARY KEY,
+  student_id INTEGER NOT NULL REFERENCES students(id),
+  sponsor_id INTEGER REFERENCES students(id),
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+CREATE TABLE commissions (
+  id           SERIAL PRIMARY KEY,
+  purchase_id  INTEGER NOT NULL REFERENCES purchases(id),
+  instructor_id INTEGER NOT NULL REFERENCES instructors(id),
+  level        INTEGER NOT NULL,
+  amount       NUMERIC(10,2) NOT NULL,
+  created_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- add other tables below if you already had them …

--- a/lib/postgresRepo.ts
+++ b/lib/postgresRepo.ts
@@ -87,7 +87,23 @@ const pgRepo: Repo = {
        RETURNING id`,
       [studentId, courseId, amount]
     );
-    return rows[0].id;
+    const purchaseId = rows[0].id;
+
+    const { rows: cRows } = await pool.query<{ instructor_id: number }>(
+      'SELECT instructor_id FROM courses WHERE id = $1',
+      [courseId]
+    );
+    const instructorId = cRows[0]?.instructor_id;
+    if (instructorId) {
+      await pool.query('SELECT distribute_commission($1,$2,$3,$4)', [
+        purchaseId,
+        courseId,
+        amount,
+        instructorId,
+      ]);
+    }
+
+    return purchaseId;
   },
 
   async instructorEarnings(instructorId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "^8",
         "eslint-config-next": "15.0.0",
         "postcss": "^8.5.6",
-        "tailwindcss": "^3.4.17",
+        "tailwindcss": "^4.1.10",
         "typescript": "^5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^8",
     "eslint-config-next": "15.0.0",
     "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.1.10",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade dev dependency to TailwindCSS v4
- flesh out database schema with students, modules, lessons and affiliate tables
- trigger the `distribute_commission` procedure after purchases
- expose instructor course list via new `/instructor/courses` page
- provide `.env.example` and placeholder `uploads/` folder

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db2b3321c8325a48fbf19a08c2375