### PR TITLE
Enhance global styling and base components

### DIFF
--- a/app/create-course/step-1-details/page.tsx
+++ b/app/create-course/step-1-details/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { useForm } from "react-hook-form";
 import Stepper from "@/components/Stepper";
+import Input from "@/components/Input";
+import Textarea from "@/components/Textarea";
+import Button from "@/components/Button";
 
 export default function Step1() {
   const { register, handleSubmit } = useForm();
@@ -13,24 +16,13 @@ export default function Step1() {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
         <div>
           <label className="mb-1 block text-sm">Title</label>
-          <input
-            {...register("title", { required: true })}
-            className="w-full rounded border px-3 py-2"
-          />
+          <Input {...register("title", { required: true })} />
         </div>
         <div>
           <label className="mb-1 block text-sm">Description</label>
-          <textarea
-            {...register("description", { required: true })}
-            className="h-28 w-full rounded border px-3 py-2"
-          />
+          <Textarea {...register("description", { required: true })} className="h-28" />
         </div>
-        <button
-          type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-white"
-        >
-          Save & Next
-        </button>
+        <Button type="submit">Save & Next</Button>
       </form>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,12 +1,18 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #2563eb;
+  --primary-foreground: #ffffff;
+  --muted: #f3f4f6;
+  --border: #d1d5db;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --muted: #1f2937;
+    --border: #334155;
   }
 }
 
@@ -19,7 +25,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/app/instructor/dashboard/page.tsx
+++ b/app/instructor/dashboard/page.tsx
@@ -11,8 +11,8 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Instructor Dashboard</h1>
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold">Instructor Dashboard</h1>
 
       <section className="grid gap-4 sm:grid-cols-3">
         <Card title="Total Earnings">${stats.earnings}</Card>
@@ -20,7 +20,7 @@ export default function Dashboard() {
         <Card title="Pending Payout">{stats.pending}</Card>
       </section>
 
-      <section className="rounded-xl border bg-white p-4 shadow">
+      <section className="rounded-xl border bg-white p-6 shadow">
         <h2 className="mb-2 text-sm font-semibold text-slate-600">
           Earnings – Last 30 Days
         </h2>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,16 @@
 import "@/app/globals.css";
 import Layout from "@/components/Layout";
+import localFont from "next/font/local";
+
+const geist = localFont({
+  src: "./fonts/GeistVF.woff",
+  variable: "--font-geist",
+});
+
+const geistMono = localFont({
+  src: "./fonts/GeistMonoVF.woff",
+  variable: "--font-geist-mono",
+});
 
 export const metadata = {
   title: "Success Academy",
@@ -12,8 +23,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className={`${geist.variable} ${geistMono.variable}`}>\
+      <body className="font-sans">
         <Layout>{children}</Layout>
       </body>
     </html>

--- a/app/student/catalog/page.tsx
+++ b/app/student/catalog/page.tsx
@@ -13,8 +13,8 @@ export default function Catalog() {
   }, []);
 
   return (
-    <div>
-      <h1 className="mb-6 text-2xl font-bold">Catalog</h1>
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold">Catalog</h1>
 
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {data.map((c) => (

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from "react";
+
+export default function Button({ className = "", ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,0 +1,10 @@
+import { InputHTMLAttributes } from "react";
+
+export default function Input({ className = "", ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={`w-full rounded border border-border bg-white px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+      {...props}
+    />
+  );
+}

--- a/components/Textarea.tsx
+++ b/components/Textarea.tsx
@@ -1,0 +1,10 @@
+import { TextareaHTMLAttributes } from "react";
+
+export default function Textarea({ className = "", ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={`w-full rounded border border-border bg-white px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+      {...props}
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,22 @@
 import type { Config } from "tailwindcss";
 const config: Config = {
-  content: ["./app/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-geist)", "sans-serif"],
+        mono: ["var(--font-geist-mono)", "monospace"],
+      },
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        primary: "var(--primary)",
+        "primary-foreground": "var(--primary-foreground)",
+        muted: "var(--muted)",
+        border: "var(--border)",
+      },
+    },
+  },
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
## Summary
- integrate local Geist fonts via `next/font/local`
- customize CSS variables and Tailwind theme
- add `Button`, `Input`, and `Textarea` components
- apply updated styling on course wizard and dashboards

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de7103cb8832581b160417561c8b8