### PR TITLE
fix: remove stray backslash from root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geist.variable} ${geistMono.variable}`}>\
+    <html lang="en" className={`${geist.variable} ${geistMono.variable}`}> 
       <body className="font-sans">
         <Layout>{children}</Layout>
       </body>


### PR DESCRIPTION
## Summary
- remove stray backslash in `app/layout.tsx` causing hydration errors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685def93760c8325b9680ee3473d4146